### PR TITLE
enabled prev_act, use/destroy/sell/buy

### DIFF
--- a/feature_extractor/game_state.py
+++ b/feature_extractor/game_state.py
@@ -15,6 +15,8 @@ class GameState:
     self.curr_obs = None
     self.prev_obs = None
 
+    self.prev_atns = None
+
   def reset(self, init_obs):
     self.curr_step = 0
     self.prev_obs = init_obs
@@ -38,5 +40,8 @@ class GameState:
     return arr
 
   def previous_actions(self):
-    # xcxc
-    return np.zeros((self.team_size, 4), dtype=np.float32)
+    if self.prev_atns is None:
+      atn_dim = len(ModelArchitecture.ACTION_NUM_DIM)
+      return np.zeros((self.team_size, atn_dim), dtype=np.float32)
+
+    return np.array(list(self.prev_atns.values()), dtype=np.float32).T

--- a/feature_extractor/map_helper.py
+++ b/feature_extractor/map_helper.py
@@ -179,20 +179,7 @@ class MapHelper:
           feat_arr.append(near_tile_map[i, j] == material.Herb.index) # herb_arr
           feat_arr.append(near_tile_map[i, j] == material.Fish.index) # fish_arr
           feat_arr.append(near_tile_map[i, j] in material.Impassible.indices) # obstacle_arr
-
-        # TODO: add poison map and modify ModelArchitecture.n_nearby_feat accordingly
-        #if abs(i-nearby_dist//2) + abs(j-nearby_dist//2) <= 0: # 1:
-          # CHECK ME: poison_map values can go over 1, unlike the above values
-          #feat_arr.append(max(0, self.poison_map[row+i, col+j]) / POISON_CLIP)
-
-    # CHECK ME: the below lines had the comment: "patch after getting trained"
-    #   It looks like they added poison map after training the model,
-    #   and they did so to NOT change the dimension
-    # food_arr[-1] = max(0, self.poison_map[row, col]) / POISON_CLIP
-    # water_arr[-1] = max(0, self.poison_map[row+1, col]) / POISON_CLIP
-    # herb_arr[-1] = max(0, self.poison_map[row, col+1]) / POISON_CLIP
-    # fish_arr[-1] = max(0, self.poison_map[row-1, col]) / POISON_CLIP
-    # obstacle_arr[-1] = max(0, self.poison_map[row, col-1]) / POISON_CLIP
+          feat_arr.append(max(0, self.poison_map[row+i, col+j]) / POISON_CLIP) # poison map
 
     return np.array(feat_arr, dtype=np.float32)
 
@@ -200,14 +187,13 @@ class MapHelper:
     return np.zeros(ModelArchitecture.NEARBY_NUM_FEATURES, dtype=np.float32)
 
   def legal_moves(self, obs):
-    # NOTE: config.PROVIDE_ACTION_TARGETS is set to True to get the action targerts
-    # CHECK ME: ACTION_NUM_DIM was changed to 4 (from 5)
+    assert self.config.PROVIDE_ACTION_TARGETS,\
+      "config.PROVIDE_ACTION_TARGETS must be set True"
     moves = np.zeros((self._team_size, len(action.Direction.edges)), dtype=np.float32)
     for member_pos in range(self._team_size):
       ent_id = self._entity_helper.pos_to_agent_id(member_pos)
       if ent_id in obs:
         moves[member_pos] = obs[ent_id]["ActionTargets"][action.Move][action.Direction]
-
 
     return moves
 

--- a/model/model.py
+++ b/model/model.py
@@ -13,15 +13,7 @@ class ModelArchitecture:
 
   NUM_TEAMS = 16
   NUM_PLAYERS_PER_TEAM = 8
-
-  # Actions
-  ACTION_NUM_DIM = {
-    'style' : 3,
-    'target': 9 + 9 + 1, # 9 npcs 9 enemies + 1 for no target
-    'move': 5, # 4 dirs + 1 for no move
-    # 'use': 3,
-    # 'sell': 3
-  }
+  INVENTORY_CAPACITY = 12
 
   # Observations
   TILE_NUM_CHANNELS = 7
@@ -34,12 +26,29 @@ class ModelArchitecture:
   ENTITY_NUM_NPCS_CONSIDERED = 9
   ENTITY_NUM_ENEMIES_CONSIDERED = 9
 
+  # TODO: let the policy consider what to buy
+  #MARKET_NUM_LISTINGS_CONSIDERED = 20
+
+  # Actions
+  # NOTE: The order of policy heads are the same as here, 
+  #   but gym.spaces.Dict sorts the keys, so the orders can be different
+  # CHECK ME: A hack -- number prefixes were added to keep the order same
+  ACTION_NUM_DIM = {
+    '10_move': 5, # 4 dirs + 1 for no move
+    '21_style' : 3,
+    # 9 npcs 9 enemies + 1 for no target
+    '22_target': ENTITY_NUM_NPCS_CONSIDERED + ENTITY_NUM_ENEMIES_CONSIDERED + 1, # for no attack
+    '30_use': INVENTORY_CAPACITY + 1, # for no use
+    '40_destroy': INVENTORY_CAPACITY + 1, # for no destroy
+    '50_sell': INVENTORY_CAPACITY + 1, # for no sell
+  }
+
   # the game progress is encoded with multi-hot-generator
   PROGRESS_NUM_FEATURES = 16 # index=int(1+16*curr_step/config.HORIZON)
   # game_progress (1), n_alive/team_size (1), n_progress_feat, team_size
   GAME_NUM_FEATURES = 1 + 1 + PROGRESS_NUM_FEATURES + NUM_PLAYERS_PER_TEAM
 
-  NEARBY_NUM_FEATURES = 205
+  NEARBY_NUM_FEATURES = 246
 
   # Melee, Ranged, Magic - only considering combat types
   NUM_PROFESSIONS = 3

--- a/model/model.py
+++ b/model/model.py
@@ -1,13 +1,17 @@
 # TODO: remove the below line, eventually...
 # pylint: disable=all
 from attr import dataclass
+from collections import OrderedDict
 
 import torch
 from .resnet import ResNet
 from .mlp import MLPEncoder
 import torch.nn as nn
 
-# Gather the moodel-related constants here
+def sort_dict_by_key(dict):
+  return OrderedDict((key, dict[key]) for key in sorted(dict.keys()))
+  
+# Gather the model-related constants here
 @dataclass
 class ModelArchitecture:
 
@@ -32,16 +36,16 @@ class ModelArchitecture:
   # Actions
   # NOTE: The order of policy heads are the same as here, 
   #   but gym.spaces.Dict sorts the keys, so the orders can be different
-  # CHECK ME: A hack -- number prefixes were added to keep the order same
-  ACTION_NUM_DIM = {
-    '10_move': 5, # 4 dirs + 1 for no move
-    '21_style' : 3,
+  #   So, sort_dict_by_key func was used to match these.
+  ACTION_NUM_DIM = sort_dict_by_key({
+    'move': 5, # 4 dirs + 1 for no move
+    'style' : 3,
     # 9 npcs 9 enemies + 1 for no target
-    '22_target': ENTITY_NUM_NPCS_CONSIDERED + ENTITY_NUM_ENEMIES_CONSIDERED + 1, # for no attack
-    '30_use': INVENTORY_CAPACITY + 1, # for no use
-    '40_destroy': INVENTORY_CAPACITY + 1, # for no destroy
-    '50_sell': INVENTORY_CAPACITY + 1, # for no sell
-  }
+    'target': ENTITY_NUM_NPCS_CONSIDERED + ENTITY_NUM_ENEMIES_CONSIDERED + 1, # for no attack
+    'use': INVENTORY_CAPACITY + 1, # for no use
+    'destroy': INVENTORY_CAPACITY + 1, # for no destroy
+    'sell': INVENTORY_CAPACITY + 1, # for no sell
+  })
 
   # the game progress is encoded with multi-hot-generator
   PROGRESS_NUM_FEATURES = 16 # index=int(1+16*curr_step/config.HORIZON)

--- a/model/policy.py
+++ b/model/policy.py
@@ -95,7 +95,8 @@ class BaselinePolicy(pufferlib.models.Policy):
                for a in actions]
 
     team_actions = []
-    for action in [actions[2], actions[0], actions[1]]:
+    # action ordering fixed. see ModelArchitecture.ACTION_NUM_DIM
+    for action in actions:
       for player in range(ModelArchitecture.NUM_PLAYERS_PER_TEAM):
         team_actions.append(action[:, player, :])
 

--- a/nmmo_team_env.py
+++ b/nmmo_team_env.py
@@ -47,7 +47,7 @@ class NMMOTeamEnv(TeamEnv):
       "npc_mask": self._box(team_size),
       "game": self._box(ModelArchitecture.GAME_NUM_FEATURES),
       "legal": action_space,
-      "prev_act": action_space,
+      "prev_act": self._box(team_size, len(ModelArchitecture.ACTION_NUM_DIM)),
       "reset": self._box(1),
     })
 
@@ -69,12 +69,12 @@ class NMMOTeamEnv(TeamEnv):
     return obs
 
   def step(self, actions: Dict[int, Dict[str, Any]]):
-    actions = {
+    trans_actions = {
       tid: self._feature_extractors[tid].translate_actions(a)
       for tid, a in actions.items()
     }
 
-    obs, rewards, dones, infos = super().step(actions)
+    obs, rewards, dones, infos = super().step(trans_actions)
     for tid, team_obs in obs.items():
       obs[tid] = self._feature_extractors[tid](
         self._convert_team_obs_to_agent_ids(tid, team_obs))

--- a/tests/feature_extractor/test_feature_extractor.py
+++ b/tests/feature_extractor/test_feature_extractor.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 
 import nmmo
 
@@ -13,25 +14,75 @@ class TestFeatureExtractor(FeaturizerTestTemplate):
 
   feature_extractors = None
 
-  def test_init_reset_call(self):
-    self.feature_extractors = {
+  def _create_test_env(self):
+    feature_extractors = {
         team_id: FeatureExtractor(self.team_helper.teams, team_id, self.config)
         for team_id in self.team_helper.teams }
 
     env = nmmo.Env(self.config, RANDOM_SEED)
     init_obs = env.reset()
 
-    for team_id, feat_ext in self.feature_extractors.items():
+    for team_id, feat_ext in feature_extractors.items():
       team_obs = self._filter_obs(init_obs, team_id)
       feat_ext.reset(team_obs)
 
+    return env, feature_extractors
+
+  def test_init_reset_call(self):
+    env, feature_extractors = self._create_test_env()
+
     # step, get team obs, update the feature extractor
     obs, _, _, _ = env.step({})
-    for team_id, feat_ext in self.feature_extractors.items():
+    for team_id, feat_ext in feature_extractors.items():
       team_obs = self._filter_obs(obs, team_id)
       feat_ext(team_obs)
 
-  def test_trans_action(self):
+  @staticmethod
+  def _get_idx(arr, get_zero=True):
+    if len(arr) > 0:
+      indices = np.where((arr == 0) == get_zero)[0]
+      if len(indices) > 0:
+        return np.random.choice(indices)
+
+    # if not found, return 0 -> the rest of the code should handle this
+    return 0
+
+  def test_trans_action_attack_targets(self):
+    env, feature_extractors = self._create_test_env()
+
+    # just look at the team 1
+    team_id = 1
+    team_size = len(self.team_helper.teams[team_id])
+    featurizer = feature_extractors[team_id]
+
+    # peeking featurizer.entity_helper._entity_targets
+    entity_targets = featurizer.entity_helper._entity_targets
+    # the first four get the index of zeros, 
+    # the next four get the index of non-zeros
+    targets = [self._get_idx(entity_targets[member_pos]) if member_pos < 4
+               else self._get_idx(entity_targets[member_pos], get_zero=False)
+               for member_pos in range(team_size)]
+    
+    # input actions are all zeros
+    input_actions = {
+      'move': np.zeros(team_size, dtype=np.int32), # idx for action.Direction.edges
+      'style': np.zeros(team_size, dtype=np.int32), # idx for action.Style.edges
+      # idx for entity_helper._entity_targets[member_pos] -> entity id
+      'target': np.array(targets, dtype=np.int32),
+    }
+
+    trans_actions = featurizer.translate_actions(input_actions)
+
+    for member_pos in range(team_size):
+      target_ent = entity_targets[member_pos][targets[member_pos]]
+      if target_ent > 0:
+        self.assertEqual(target_ent,
+                         trans_actions[member_pos][nmmo.action.Attack][nmmo.action.Target])
+      else:
+        self.assertTrue(nmmo.action.Attack not in trans_actions[member_pos])
+
+    print()
+
     pass
 
 


### PR DESCRIPTION
* the actual prev_actions are fed into the obs
* policy.py,  `decode_actions()` : removed shuffling actions around -- matched the action key order in the model.py and gym spaces.
* the agent can use, destroy, sell, buy. 
  * use/sell: the policy computes the actions, but the featurizer's force_use/sell overrides it. NOTE: realikun didn't consider ammos seriously, so ammos are the first thing agents sell, regardless of profession. Let's see how it goes. 
  * destroy: the policy decides, as the featurizer doesn't consider it
  * buy: for now, the featurizer decides it entirely. will let the policy suggests it.
* properly included the poison map to the nearby features

TODO: give, give-gold actions need to be implemented. For price, it'd be great to have a continuous policy head than a discrete head.

Tested with all systems uncommented in `main.py`:
```python
  class TrainConfig(
    nmmo.config.Medium,
    nmmo.config.Terrain,
    nmmo.config.Resource,
    nmmo.config.NPC,
    nmmo.config.Progression,
    nmmo.config.Equipment,
    nmmo.config.Item,
    nmmo.config.Exchange,
    nmmo.config.Profession,
    nmmo.config.Combat,
  ):
```