### PR TITLE
made all tests pass again (locally at least)

### DIFF
--- a/.github/workflows/pylint-test.yml
+++ b/.github/workflows/pylint-test.yml
@@ -18,7 +18,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
-        pip install pytest==7.2.2
     - name: Running unit tests
       run: pytest
     # NOTE: will put these back eventually

--- a/env/nmmo_team_env.py
+++ b/env/nmmo_team_env.py
@@ -1,6 +1,5 @@
 
-from dataclasses import dataclass
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import gym
 import nmmo
@@ -13,6 +12,7 @@ from model.realikun.model import ModelArchitecture
 from env.nmmo_env import NMMOEnv, RewardsConfig
 
 class NMMOTeamEnv(TeamEnv):
+  # pylint: disable=arguments-renamed
   def __init__(self, config: nmmo.config.Config(), team_helper: TeamHelper,
                rewards_config: RewardsConfig,
                moves_only: bool = False):
@@ -21,7 +21,8 @@ class NMMOTeamEnv(TeamEnv):
 
     self._config = config
     self._feature_extractors = [
-      FeatureExtractor(team_helper.teams, tid, config, moves_only=moves_only) for tid in team_helper.teams
+      FeatureExtractor(team_helper.teams, tid, config, moves_only=moves_only)
+      for tid in team_helper.teams
     ]
 
   def _box(self, *shape):
@@ -102,4 +103,3 @@ class NMMOTeamEnv(TeamEnv):
       self._team_helper.agent_id(team_id, pos): obs
       for pos, obs in team_obs.items()
     }
-

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,66 +1,31 @@
-'''Manual test for deterministic rollout with baseline agents'''
-from tqdm import tqdm
-import numpy as np
-import random
+# pylint: disable=protected-access
 
-import nmmo
+'''Manual test for deterministic rollout with baseline agents'''
+import random
+import unittest
+import numpy as np
+from tqdm import tqdm
+
 from pufferlib.emulation import Binding
 
 from env.nmmo_env import RewardsConfig
+from env.nmmo_config import NmmoConfig
 from env.nmmo_team_env import NMMOTeamEnv
 from lib.team.team_helper import TeamHelper
 from model.realikun.model import ModelArchitecture
 from model.realikun.baseline_agent import BaselineAgent
 
 HORIZON = 30
+RANDOM_SEED = random.randint(0, 100000)
 MODEL_WEIGHTS = '../model_weights/achievements_4x10_new.200.pt'
 
-class ReplayConfig(
-  nmmo.config.Medium,
-  nmmo.config.Terrain,
-  nmmo.config.Resource,
-  nmmo.config.NPC,
-  nmmo.config.Progression,
-  nmmo.config.Equipment,
-  nmmo.config.Item,
-  nmmo.config.Exchange,
-  nmmo.config.Profession,
-  nmmo.config.Combat,
-):
-  SAVE_REPLAY = True
-  PROVIDE_ACTION_TARGETS = True
-  PLAYER_N = ModelArchitecture.NUM_TEAMS * ModelArchitecture.NUM_PLAYERS_PER_TEAM
-  NPC_N = 64
+def init_team_env(model_weights):
+  num_teams = ModelArchitecture.NUM_TEAMS
+  team_size = ModelArchitecture.NUM_PLAYERS_PER_TEAM
 
-def get_rollout_actions(team_env, agent_list, seed):
-  team_obs = team_env.reset(seed=seed)
-
-  saved_actions = {}
-  for step in tqdm(range(HORIZON)):
-    # generate actions
-    saved_actions[step] = { team_id: agent_list[team_id].act(obs)
-                              for team_id, obs in team_obs.items() }
-    team_obs, _, _, _ = team_env.step(saved_actions[step])
-
-  event_log = team_env._env.realm.event_log.get_data()
-
-  return saved_actions, event_log
-
-def rollout_with_saved_actions(team_env, seed, saved_actions):
-  team_env.reset(seed=seed)
-  for step in tqdm(range(HORIZON)):
-    team_env.step(saved_actions[step])
-
-  # return the event log for comparison
-  return team_env._env.realm.event_log.get_data()
-
-def test_determinism(seed, model_weights=MODEL_WEIGHTS):
-  config = ReplayConfig()
+  config = NmmoConfig(num_teams=num_teams, team_size=team_size)
   reward_config = RewardsConfig()
 
-  # NOTE: using hardcoded values
-  team_size = ModelArchitecture.NUM_PLAYERS_PER_TEAM
-  num_teams = ModelArchitecture.NUM_TEAMS
   team_helper = TeamHelper({
     i: [i*team_size+j+1 for j in range(team_size)]
     for i in range(num_teams)}
@@ -78,13 +43,59 @@ def test_determinism(seed, model_weights=MODEL_WEIGHTS):
   for _ in range(num_teams):
     agent_list.append(BaselineAgent(model_weights, binding))
 
+  return team_env, agent_list
+
+def get_rollout_actions(team_env, agent_list, seed):
+  team_obs = team_env.reset(seed=seed, map_id=0)
+
+  saved_actions = {}
+  for step in tqdm(range(HORIZON)):
+    # generate actions
+    saved_actions[step] = { team_id: agent_list[team_id].act(obs)
+                              for team_id, obs in team_obs.items() }
+    team_obs, _, _, _ = team_env.step(saved_actions[step])
+
+  event_log = team_env._env.realm.event_log.get_data()
+
+  return saved_actions, event_log
+
+def rollout_with_saved_actions(team_env, seed, saved_actions):
+  team_env.reset(seed=seed, map_id=0)
+  for step in tqdm(range(HORIZON)):
+    team_env.step(saved_actions[step])
+
+  # return the event log for comparison
+  return team_env._env.realm.event_log.get_data()
+
+def run_rollouts(model_weights, seed):
+  team_env, agent_list = init_team_env(model_weights)
   saved_actions, src_log = get_rollout_actions(team_env, agent_list, seed)
   rep_log = rollout_with_saved_actions(team_env, seed, saved_actions)
 
-  assert np.array_equal(src_log, rep_log), "Two rollouts are not the same."
+  return src_log, rep_log, saved_actions
+
+class TestDeterminism(unittest.TestCase):
+  def test_determinism(self):
+    src_log, rep_log, _ = run_rollouts(model_weights=MODEL_WEIGHTS, seed=RANDOM_SEED)
+
+    # import pickle
+    # with open('actions.pickle', 'wb') as f:
+    #   pickle.dump(saved_actions, f)
+
+    assert np.array_equal(src_log, rep_log),\
+      f"The determinism test failed with the seed: {RANDOM_SEED}."
 
 
 if __name__ == '__main__':
-  seed = random.randint(0, 100000)
-  test_determinism(seed)
-  print(f"Test passed with seed {seed}")
+  unittest.main()
+
+  # team_env, agent_list = init_team_env(MODEL_WEIGHTS)
+  # with open('actions.pickle', 'rb') as f:
+  #   saved_actions = pickle.load(f)
+  # rep_log = rollout_with_saved_actions(team_env, RANDOM_SEED, saved_actions)
+  # rep2_log = rollout_with_saved_actions(team_env, RANDOM_SEED, saved_actions)
+
+  # np.savetxt("rep_log1.csv", rep_log, delimiter=',', fmt="%d")
+  # np.savetxt("rep_log2.csv", rep2_log, delimiter=',', fmt="%d")
+
+  # assert np.array_equal(rep_log, rep2_log)

--- a/tests/test_team_env.py
+++ b/tests/test_team_env.py
@@ -8,6 +8,9 @@ from lib.team.team_env import TeamEnv
 
 from lib.team.team_helper import TeamHelper
 
+def get_val(data: Dict):
+  return list(data.values())[0]
+
 class TestEnv(ParallelEnv):
   # pylint: disable=abstract-method,unused-argument
   def __init__(self):
@@ -34,8 +37,8 @@ class TestEnv(ParallelEnv):
 
   def step(self, actions: Dict[int, Any]):
     obs = self.reset()
-    rewards = {i: action * 0.5 for i, action in actions.items()}
-    dones = {i: action == self.action_space_map[i].n - 1 for i, action in actions.items()}
+    rewards = {i: get_val(action) for i, action in actions.items()}
+    dones = {i: get_val(action) == self.action_space_map[i].n - 1 for i, action in actions.items()}
     infos = {i: {} for i in actions.keys()}
     return obs, rewards, dones, infos
 
@@ -58,7 +61,7 @@ class TestTeamEnv(unittest.TestCase):
                             1: {0: np.array([0.6, 0.7]), 1: np.array([0.8, 0.9, 1.0])}})
 
     # Test step
-    team_actions = {0: {0: 1, 1: 2}, 1: {0: 1, 1: 1}}
+    team_actions = {0: {0: {1: 1}, 1: {2: 2}}, 1: {0: {1: 1}, 1: {1: 1}}}
     obs, rewards, dones, infos = team_env.step(team_actions)
 
     expected_obs = {0: {0: np.array([0.1, 0.2]), 1: np.array([0.3, 0.4, 0.5])},


### PR DESCRIPTION
Successfully running tests in github actions requires pip installable nmmo 2.0 and pufferlib. The tests ran well locally, and once they are up, the tests should pass here too.

* potential bug fixes in team_env.py: 
   * the line `for pos in range(len(team_action)):` may return `pos` that are not in `team_action`
   * `len(team_dones)` sums up both done = True and False, but we only want Trues, right?

* refactored the determinism test: found that not resetting the datastore's id allocator can break determinism because the id allocators can have different max_id, frees between the initial and subsequent runs. The env PR: https://github.com/CarperAI/nmmo-environment/pull/61