### PR TITLE
Select learnable tasks based on task progress metrics

### DIFF
--- a/curriculum_generation/elm.py
+++ b/curriculum_generation/elm.py
@@ -27,7 +27,7 @@ from openelm.environments import BaseEnvironment, Genotype
 from openelm.mutation_model import MutationModel
 from openelm.configs import ELMConfig, MAPElitesConfig, PromptModelConfig
 
-from curriculum_generation.task_sampler import RandomTaskSampler
+from curriculum_generation.task_sampler import LearnableTaskSampler
 
 
 # used in OpenELMTaskGenerator: see self.config.env.impr = import_str["short_import"]
@@ -388,7 +388,7 @@ class NMMOTaskFn(Genotype):
             return None
 
 
-class OpenELMTaskGenerator(RandomTaskSampler):
+class OpenELMTaskGenerator(LearnableTaskSampler):
     """Container class to include all the configs and generate tasks"""
 
     def __init__(
@@ -439,7 +439,7 @@ class OpenELMTaskGenerator(RandomTaskSampler):
 
     def evolve_tasks(
         self, task_spec: List[ts.TaskSpec], num_tasks, steps=10, debug=False
-    ):
+    ) -> List[ts.TaskSpec]:
         """Evolve the given task specs for the given number of steps
         and return the num_tasks task specs
         """
@@ -455,6 +455,7 @@ class OpenELMTaskGenerator(RandomTaskSampler):
             elm.run(init_steps=2, total_steps=steps)
             # for now, just using the maximum fitness genome
             # TODO: we may want to sample best ones across the MAP (see MAP-Elites)
+            # TODO: vary the name of generated functions. Now, it's all training_task (self.gen_fn_name)
             best_task = elm.qd_algorithm.current_max_genome
 
         return best_task.generate_task_spec(num_tasks)

--- a/curriculum_generation/task_sampler.py
+++ b/curriculum_generation/task_sampler.py
@@ -1,27 +1,82 @@
 from typing import List
-import inspect
-import random
+from collections import defaultdict
+import numpy as np
 
-import nmmo
 from nmmo.task import task_spec as ts
-import nmmo.task.base_predicates
 
-class RandomTaskSampler:
-    def __init__(self, task_spec: List[ts.TaskSpec]):
+class LearnableTaskSampler:
+    def __init__(self,
+                 task_spec: List[ts.TaskSpec],
+                 average_window = 50):
         self.task_spec = task_spec
-        self.eval_fn_code = self._get_eval_fn_code()
+        self.name_to_spec = {single_spec.name: single_spec for single_spec in self.task_spec}
+        self.task_stats = {}
+        self.average_window = average_window
 
-    def _get_eval_fn_code(self):
-        # get the whole pre-built eval functions
-        code = inspect.getsource(nmmo.task.base_predicates)
-        # go through the task_spec and include the code of new functions
-        for spec in self.task_spec:
-            if not hasattr(nmmo.task.base_predicates, spec.eval_fn.__name__):
-                code += "\n" + inspect.getsource(spec.eval_fn)
-        return code
+    def reset(self):
+        self.task_stats = {}
 
-    def sample_tasks(self, num_tasks):
-        # returning the task spec, which is sampled with replacement
-        # CHECK ME: do we need to provide a random task generator?
-        #   providing a manually curated task could do
-        return random.choices(self.task_spec, k=num_tasks)
+    def add_tasks(self, task_spec: List[ts.TaskSpec]):
+        # so that the stats for the new tasks can be tracked
+        for new_spec in task_spec:
+            if new_spec.name not in self.name_to_spec:
+                self.task_spec.append(new_spec)
+                self.name_to_spec[new_spec.name] = new_spec
+
+    def update(self, infos, prefix="curriculum/"):
+        for key, val in infos.items():
+            # Process the new infos
+            if key.startswith(prefix):
+                spec_name = key.replace(prefix,"")
+                completed, prog_over_10pcnt, rcnt_over_2 = [], [], []
+                for sublist in val:
+                    for prog, rcnt in sublist:
+                        completed.append(float(prog >= 1))
+                        rcnt_over_2.append(float(rcnt >= 2)) # rewarded >= 2 times
+
+                # Add to the task_stats
+                if spec_name not in self.task_stats:
+                    self.task_stats[spec_name] = defaultdict(list)
+                self.task_stats[spec_name]["completed"] += completed
+                self.task_stats[spec_name]["rcnt_over_2"] += rcnt_over_2
+
+                # Keep only the recent values -- self.average_window (50)
+                for key, vals in self.task_stats[spec_name].items():
+                    self.task_stats[spec_name][key] = vals[-self.average_window:]
+
+    def get_learnable_tasks(self, num_tasks,
+                               max_completed = 0.8, # filter out easy tasks
+                               min_completed = 0.05, # filter out harder tasks
+                               min_rcnt_rate = 0.1, # reward signal generating
+    ) -> List[ts.TaskSpec]:
+        learnable = []
+        for spec_name, stat in self.task_stats.items():
+            completion_rate = np.mean(stat["completed"])
+            rcnt_over2_rate = np.mean(stat["rcnt_over_2"])
+            if completion_rate < max_completed and\
+              (completion_rate >= min_completed or rcnt_over2_rate >= min_rcnt_rate):
+                learnable.append(self.name_to_spec[spec_name])
+
+        if len(learnable) > num_tasks:
+            return list(np.random.choice(learnable, num_tasks))
+        return learnable
+
+    def sample_tasks(self, num_tasks,
+                     random_ratio = 0.5,
+                     reset_sampling_weight = True,
+    ) -> List[ts.TaskSpec]:
+        task_spec = []
+        if 0 <= random_ratio < 1:
+            num_learnable = round(num_tasks * (1-random_ratio))
+            task_spec = self.get_learnable_tasks(num_learnable)
+
+        # fill in with the randomly-sampled tasks
+        # TODO: sample more "less-sampled" tasks (i.e., no or little stats)
+        num_sample = num_tasks - len(task_spec)
+        task_spec += list(np.random.choice(self.task_spec, num_sample))
+
+        if reset_sampling_weight:
+            for single_spec in task_spec:
+                single_spec.sampling_weight = 1
+
+        return task_spec

--- a/environment.py
+++ b/environment.py
@@ -67,6 +67,7 @@ class Postprocessor(pufferlib.emulation.Postprocessor):
         self._cod_starved = 0
         self._cod_dehydrated = 0
         self._task_completed = 0
+        self._curriculum = defaultdict(list)
 
     def rewards(self, team_rewards, team_dones, team_infos, step):
         """Calculate team rewards and update stats."""
@@ -83,6 +84,8 @@ class Postprocessor(pufferlib.emulation.Postprocessor):
                     continue
 
                 task = self.env.agent_task_map[agent_id][0]
+                # For each task spec, record whether its max progress and reward count
+                self._curriculum[task.spec_name].append((task._max_progress, task._reward_count))
                 if task.completed:
                     self._task_completed += 1.0 / self.team_size
 
@@ -105,6 +108,7 @@ class Postprocessor(pufferlib.emulation.Postprocessor):
             team_infos["stats"]["cod/starved"] = self._cod_starved
             team_infos["stats"]["cod/dehydrated"] = self._cod_dehydrated
             team_infos["stats"]["task/completed"] = self._task_completed
+            team_infos["curriculum"] = self._curriculum
 
             achieved, performed, _ = process_event_log(
                 self.env.realm, self.teams[self.team_id]

--- a/reinforcement_learning/config.py
+++ b/reinforcement_learning/config.py
@@ -52,7 +52,7 @@ class LocalConfig(Config):
     # A smaller config for local testing that won't OOM your machine
     num_envs = 1  # Number of environments to use for training
     num_buffers = 1  # Number of buffers to use for training
-    rollout_batch_size = 2**12  # Number of steps to rollout
+    #rollout_batch_size = 2**12  # Number of steps to rollout
 
 
 def create_config(config_cls):


### PR DESCRIPTION
* Task progress metrics (max progress, # of positive rewards) are processed in the `Postprocessor()`, and can be accessed after `trainer.evaluate()`   However, this requires these two PRs:
   * nmmo env: https://github.com/CarperAI/nmmo-environment/pull/101 
   * pufferlib: https://github.com/PufferAI/PufferLib/pull/32
* `LearnableTaskSampler()` is added, which uses the task progress metrics to sample training tasks
* The curriculum generation track in `train.py` was revised