### PR TITLE
New task embedding with the Codegen2.5 7B model

### DIFF
--- a/curriculum_generation/elm.py
+++ b/curriculum_generation/elm.py
@@ -399,8 +399,6 @@ class OpenELMTaskGenerator(LearnableTaskSampler):
         batch_size=1,
         gen_fn_name="training_task",
     ):
-        pattern = r"Salesforce/codegen-(350M|2B|6B)-mono"
-        assert re.match(pattern, checkpoint), "Provided model not supported"
         assert 0.9 <= temperature <= 1.4, "temperature should be between 0.9 and 1.4"
         super().__init__(task_spec)
 
@@ -421,6 +419,7 @@ class OpenELMTaskGenerator(LearnableTaskSampler):
         self.config.model.temp = temperature
         self.config.model.batch_size = batch_size
         self.config.model.model_path = checkpoint
+        self.config.model.load_in_8bit = True
 
     @staticmethod
     def task_spec_to_str(task_spec: List[ts.TaskSpec]):

--- a/environment.py
+++ b/environment.py
@@ -92,7 +92,7 @@ class Postprocessor(pufferlib.emulation.Postprocessor):
     def _update_stats(self, agent):
         task = self.env.agent_task_map[agent.ent_id][0]
         # For each task spec, record whether its max progress and reward count
-        self._curriculum[task.spec_name].append((task._max_progress, task._reward_count))
+        self._curriculum[task.spec_name].append((task._max_progress, task.reward_signal_count))
         if task.completed:
             self._task_completed += 1.0 / self.team_size
 

--- a/environment.py
+++ b/environment.py
@@ -39,6 +39,7 @@ class Config(
         self.MAP_CENTER = args.map_size
         self.NPC_N = args.num_npcs
         self.CURRICULUM_FILE_PATH = args.tasks_path
+        self.TASK_EMBED_DIM = args.task_size
 
 
 class Postprocessor(pufferlib.emulation.Postprocessor):

--- a/llm-agent/environment.py
+++ b/llm-agent/environment.py
@@ -1,1 +1,0 @@
-../environment.py

--- a/llm-agent/leader_board.py
+++ b/llm-agent/leader_board.py
@@ -1,0 +1,1 @@
+../leader_board.py

--- a/llm-agent/play_game.py
+++ b/llm-agent/play_game.py
@@ -1,6 +1,6 @@
 from pdb import set_trace as T
+import os
 from tqdm import tqdm
-
 import numpy as np
 
 import nmmo
@@ -8,7 +8,7 @@ from nmmo.render.replay_helper import FileReplayHelper
 
 # These files are symlinked for convenience
 from scripted import baselines
-from environment import process_event_log
+from leader_board import process_event_log
 
 from generated_agent import Agent
 
@@ -45,6 +45,7 @@ for t in tqdm(range(128)):
     _, _, d, _ = env.step({})
     agent_info += [get_agent_info(env, agent_id) for agent_id in d if d[agent_id] is True]
 
+os.makedirs('replays', exist_ok=True)
 replay_helper.save('replays/gpt-agent')
 
 # remaining agents

--- a/reinforcement_learning/config.py
+++ b/reinforcement_learning/config.py
@@ -41,7 +41,7 @@ class Config:
 
     # Policy Args
     num_lstm_layers = 0  # Number of LSTM layers to use
-    task_size = 1024  # Size of task embedding
+    task_size = 4096  # Size of task embedding
     encode_task = True  # Encode task
     attend_task = "none"  # Attend task - options: none, pytorch, nikhil
     attentional_decode = True  # Use attentional action decoder

--- a/tests/test_elm_for_nmmo.py
+++ b/tests/test_elm_for_nmmo.py
@@ -8,7 +8,7 @@ import nmmo.task.base_predicates
 import curriculum_generation.elm as elm
 from curriculum_generation import custom_curriculum as cc
 
-LLM_CHECKPOINT = "Salesforce/codegen-350M-mono"
+LLM_CHECKPOINT = "Salesforce/codegen25-7b-instruct"
 NUM_TRAIN_TASKS = 5
 NUM_TEST_TASKS = 5
 NUM_NEW_TASKS = 5

--- a/tests/test_task_encoder.py
+++ b/tests/test_task_encoder.py
@@ -4,20 +4,19 @@ import unittest
 import curriculum_generation.manual_curriculum
 from curriculum_generation.task_encoder import TaskEncoder
 
-LLM_CHECKPOINT = "Salesforce/codegen-350M-mono"
+LLM_CHECKPOINT = "Salesforce/codegen25-7b-instruct"
 CURRICULUM_FILE_PATH = "curriculum_generation/curriculum_with_embedding.pkl"
 
 # NOTE: models that are not Salesforce/codegen-350M-mono may give different number
-EMBEDDING_DIM = 1024
-
+EMBEDDING_DIM = 4096
 
 class TestTaskEncoder(unittest.TestCase):
   # pylint: disable=protected-access,bad-builtin
   @classmethod
   def setUpClass(cls):
     cls.task_encoder = TaskEncoder(
-        LLM_CHECKPOINT, curriculum_generation.manual_curriculum, batch_size=1
-    )  # see test_batch_process()
+        LLM_CHECKPOINT, curriculum_generation.manual_curriculum, batch_size=4
+    )
 
   @classmethod
   def tearDownClass(cls):
@@ -54,16 +53,6 @@ class TestTaskEncoder(unittest.TestCase):
         single_spec.reward_to, single_spec.eval_fn, single_spec.eval_fn_kwargs
     )
     print(prompt)
-
-  def test_batch_process(self):
-    batch_size = 8
-    task_encoder = TaskEncoder(
-        LLM_CHECKPOINT, curriculum_generation.manual_curriculum, batch_size=batch_size
-    )
-    batch_embedding = task_encoder._get_embedding(
-        ["# just to get the embedding size"] * batch_size
-    )
-    self.assertEqual(len(batch_embedding), batch_size)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -14,12 +14,15 @@ from reinforcement_learning import config
 from curriculum_generation import manual_curriculum
 from curriculum_generation.task_encoder import TaskEncoder
 
-LLM_CHECKPOINT = "Salesforce/codegen-350M-mono"
+LLM_CHECKPOINT = "Salesforce/codegen25-7b-instruct"
 AGENT_MODEL_PATH = ""
 NUM_SEED_TASKS = 20
 NUM_NEW_TASKS = 5
 DEBUG = True
 CURRICULUM = manual_curriculum
+
+# NOTE: this file changes when running curriculum generation track
+# Run test_task_encoder.py to regenerate this file (or get it from the repo)
 CURRICULUM_FILE_PATH = "curriculum_generation/curriculum_with_embedding.pkl"
 
 def setup_env(args):


### PR DESCRIPTION
* Tested Task encoder and open elm with the `Salesforce/codegen25-7B-instruct` model, which used less than 16gb of gpu vram
* Recreated the `curriculum_with_embedding.pkl` file with the codegen 2.5 model
* The embedding size is 4096 (from 1024), and the related configs were changed accordingly
* fixed broken thing in the `llm-agent` and `environment.py` (also see the env PR)

The type of task-embedding in the nmmo-env was incorrect, so it was also fixed. Please see the env PR:  https://github.com/CarperAI/nmmo-environment/pull/102