### PR TITLE
Specified the curriculum variable

### DIFF
--- a/curriculum_generation/task_encoder.py
+++ b/curriculum_generation/task_encoder.py
@@ -114,30 +114,30 @@ class TaskEncoder:
         The agent's goal is"""
         return task_specific_prompt
 
-    def get_task_embedding(self, task_spec: List[ts.TaskSpec], save_to_file: str = None):
+    def get_task_embedding(self, task_spec_list: List[ts.TaskSpec], save_to_file: str = None):
         """
         Compute embeddings for given task specifications and save them to file.
 
         Args:
-        task_spec: List of task specifications.
+        task_spec_list: List of task specifications.
         save_to_file: Name of the file where the results should be saved.
 
         Returns:
         Updated task specifications with embeddings.
         """
         assert self.model is not None, "Model has been unloaded. Re-initialize the TaskEncoder."
-        prompts = [self._construct_prompt(single_spec.reward_to, single_spec.eval_fn, single_spec.eval_fn_kwargs) for single_spec in task_spec]
+        prompts = [self._construct_prompt(single_spec.reward_to, single_spec.eval_fn, single_spec.eval_fn_kwargs) for single_spec in task_spec_list]
         embeddings = self._get_embedding(prompts)
 
-        for single_spec, embedding in zip(task_spec, embeddings):
+        for single_spec, embedding in zip(task_spec_list, embeddings):
             single_spec.embedding = embedding
 
         if save_to_file:  # use save_to_file as the file name
             with open(self.temp_file_path, "wb") as f:
-                dill.dump(task_spec, f)
+                dill.dump(task_spec_list, f)
             os.replace(self.temp_file_path, save_to_file)
 
-        return task_spec
+        return task_spec_list
 
     def close(self):
         # free up gpu memory
@@ -156,10 +156,10 @@ class TaskEncoder:
 if __name__ == "__main__":
     import curriculum_generation.manual_curriculum as curriculum
     LLM_CHECKPOINT = "Salesforce/codegen25-7b-instruct"
-    CURRICULUM_FILE_PATH = "curriculum_generation/curriculum_with_embedding.pkl"
+    CURRICULUM_FILE_PATH = "reinforcement_learning/curriculum_with_embedding.pkl"
 
     with TaskEncoder(LLM_CHECKPOINT, curriculum, batch_size=6) as task_encoder:
         task_encoder.get_task_embedding(
-            curriculum.task_spec,
+            curriculum.curriculum,
             save_to_file=CURRICULUM_FILE_PATH
         )

--- a/curriculum_generation/visualize_embeddings.py
+++ b/curriculum_generation/visualize_embeddings.py
@@ -9,18 +9,18 @@ try:
 except:
     print('pip install dash to use this script')
 
-CURRICULUM_FILE_PATH = "curriculum_generation/curriculum_with_embedding.pkl"
+CURRICULUM_FILE_PATH = "reinforcement_learning/curriculum_with_embedding.pkl"
 
 
 class TaskEmbeddingVisualizer:
     def __init__(self, curriculum_file_path):
         with open(curriculum_file_path, 'rb') as f:
             # TODO: de-duplication. Although, the manual curriculum doesn't have duplicates.
-            self.task_spec = dill.load(f)
-        self.embeddings = np.array([single_spec.embedding for single_spec in self.task_spec])
+            self.curriculum = dill.load(f)
+        self.embeddings = np.array([single_spec.embedding for single_spec in self.curriculum])
 
     def visualize(self, dims=2):
-        task_names = [single_spec.name for single_spec in self.task_spec]
+        task_names = [single_spec.name for single_spec in self.curriculum]
         colors = [f"#00{format(int(val), '02x')}ff" for val in np.linspace(0, 255, len(task_names))]
         task_to_color = {eval_fn: color for eval_fn, color in zip(task_names, colors)}
 

--- a/tests/test_elm_for_nmmo.py
+++ b/tests/test_elm_for_nmmo.py
@@ -1,12 +1,10 @@
 import unittest
 
 from openelm import ELM
-from openelm.mutation_model import PromptModel
-
 import nmmo.task.base_predicates
 
 import curriculum_generation.elm as elm
-from curriculum_generation import custom_curriculum as cc
+from curriculum_generation import curriculum_tutorial as tutorial
 
 LLM_CHECKPOINT = "Salesforce/codegen25-7b-instruct"
 NUM_TRAIN_TASKS = 5
@@ -21,13 +19,13 @@ VALID_TASK_FN = """def training_task(gs, subject, dist, num_tick):
 class TestElmForNmmo(unittest.TestCase):
   def test_task_generator_api(self):
     # pylint: disable=unused-variable
-    task_generator = elm.OpenELMTaskGenerator(cc.task_spec, LLM_CHECKPOINT)
-    train_task_spec = task_generator.sample_tasks(NUM_TRAIN_TASKS)
-    eval_task_spec = task_generator.sample_tasks(NUM_TEST_TASKS)
+    task_generator = elm.OpenELMTaskGenerator(tutorial.curriculum, LLM_CHECKPOINT)
+    train_task_list = task_generator.sample_tasks(NUM_TRAIN_TASKS)
+    eval_task_list = task_generator.sample_tasks(NUM_TEST_TASKS)
 
     # to actually run elm, remove debug=True
     new_task_spec = task_generator.evolve_tasks(
-        train_task_spec, NUM_NEW_TASKS, debug=False
+        train_task_list, NUM_NEW_TASKS, debug=True
     )
 
   def test_gnereate_task_spec(self):
@@ -87,7 +85,7 @@ def training_task(gs, subject):
   def test_elm_prompt(self):
     # pylint: disable=protected-access,bad-builtin
     # NOTE: this is to test different elm prompt
-    task_generator = elm.OpenELMTaskGenerator(cc.task_spec, LLM_CHECKPOINT)
+    task_generator = elm.OpenELMTaskGenerator(tutorial.curriculum, LLM_CHECKPOINT)
     train_task_spec = task_generator.sample_tasks(NUM_TRAIN_TASKS)
 
     elm_config = task_generator.config

--- a/tests/test_task_encoder.py
+++ b/tests/test_task_encoder.py
@@ -5,9 +5,9 @@ import curriculum_generation.manual_curriculum
 from curriculum_generation.task_encoder import TaskEncoder
 
 LLM_CHECKPOINT = "Salesforce/codegen25-7b-instruct"
-CURRICULUM_FILE_PATH = "curriculum_generation/curriculum_with_embedding.pkl"
+CURRICULUM_FILE_PATH = "curriculum_with_embedding.pkl"
 
-# NOTE: models that are not Salesforce/codegen-350M-mono may give different number
+# NOTE: different LLMs will give different embedding dimensions
 EMBEDDING_DIM = 4096
 
 class TestTaskEncoder(unittest.TestCase):
@@ -27,7 +27,7 @@ class TestTaskEncoder(unittest.TestCase):
 
   def test_task_encoder_api(self):
     task_spec_with_embedding = self.task_encoder.get_task_embedding(
-      curriculum_generation.manual_curriculum.task_spec,
+      curriculum_generation.manual_curriculum.curriculum,
       save_to_file=CURRICULUM_FILE_PATH
     )
 
@@ -48,7 +48,7 @@ class TestTaskEncoder(unittest.TestCase):
     self.assertTrue("def TickGE(" in deps_src)
 
   def test_contruct_prompt(self):
-    single_spec = random.choice(curriculum_generation.manual_curriculum.task_spec)
+    single_spec = random.choice(curriculum_generation.manual_curriculum.curriculum)
     prompt = self.task_encoder._construct_prompt(
         single_spec.reward_to, single_spec.eval_fn, single_spec.eval_fn_kwargs
     )


### PR DESCRIPTION
* by renamining task_spec to curriculum, which is a list of TaskSpec, to state that it is the curriculum that one should make
* corrected the location of curriculum pickle file, some of which were missed during separating the manual vs. custom curriculums files used in the rl and curriculum tracks
* renamed to task_spec to task_spec_list in a few places

Also synced with the curriculum tutorial: https://github.com/NeuralMMO/neuralmmo.github.io/pull/6