### PR TITLE
Simplified environment.py Postprocessor

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+from collections import defaultdict
 
 import nmmo
 import pufferlib
@@ -57,8 +58,9 @@ class Postprocessor(StatPostprocessor):
         """Called in _poststep() via _shape_rewards().
            See https://github.com/PufferAI/PufferLib/blob/0.3/pufferlib/emulation.py#L322
         """
-        # The below line updates the stats and does not affect the reward.
+        # The below lines update the stats and do NOT affect the reward.
         super().rewards(team_rewards, team_dones, team_infos, step)  # DO NOT REMOVE
+        team_infos = {"stats": defaultdict(float)}  # DO NOT REMOVE
 
         # Default reward shaper sums team rewards.
         # Add custom reward shaping here.

--- a/environment.py
+++ b/environment.py
@@ -5,7 +5,7 @@ import nmmo
 import pufferlib
 import pufferlib.emulation
 
-from leader_board import StatPostprocessor
+from leader_board import StatPostprocessor, score_unique_events
 
 class Config(nmmo.config.Default):
     """Configuration for Neural MMO."""
@@ -28,7 +28,6 @@ class Config(nmmo.config.Default):
         assert args.task_size == 4096, "Only support task size 4096"
 
         self.COMMUNICATION_SYSTEM_ENABLED = False
-
 
 class Postprocessor(StatPostprocessor):
     def __init__(self, env, teams, team_id, replay_save_dir=None):
@@ -64,7 +63,15 @@ class Postprocessor(StatPostprocessor):
 
         # Default reward shaper sums team rewards.
         # Add custom reward shaping here.
-        return sum(team_rewards.values()), team_infos
+
+        # Unique event-based rewards, similar to exploration bonus
+        # NOTE: this gets slower as the size of event log increases
+        # BONUS_WEIGHT = 0.01
+        # log = self.env.realm.event_log.get_data(agents=self.teams[self.team_id])
+        # explore_bonus = BONUS_WEIGHT * score_unique_events(self.env.realm, log)
+        explore_bonus = 0
+
+        return sum(team_rewards.values()) + explore_bonus, team_infos
 
     def infos(self, team_reward, env_done, team_done, team_infos, step):
         """Called in _poststep() via _handle_infos().

--- a/environment.py
+++ b/environment.py
@@ -1,14 +1,10 @@
-import os
-import time
 from argparse import Namespace
-from collections import defaultdict
 
+import nmmo
 import pufferlib
 import pufferlib.emulation
 
-import nmmo
-from nmmo.render.replay_helper import FileReplayHelper
-from leader_board import get_team_result
+from leader_board import StatPostprocessor
 
 class Config(nmmo.config.Default):
     """Configuration for Neural MMO."""
@@ -33,143 +29,49 @@ class Config(nmmo.config.Default):
         self.COMMUNICATION_SYSTEM_ENABLED = False
 
 
-class Postprocessor(pufferlib.emulation.Postprocessor):
-    """Postprocessing actions and metrics of Neural MMO."""
-
+class Postprocessor(StatPostprocessor):
     def __init__(self, env, teams, team_id, replay_save_dir=None):
-        super().__init__(env, teams, team_id)
-        self._num_replays_saved = 0
-        self._replay_save_dir = None
-        if replay_save_dir is not None and self.team_id == 1:
-            self._replay_save_dir = replay_save_dir
-        self._replay_helper = None
-        self._reset_episode_stats()
+        super().__init__(env, teams, team_id, replay_save_dir)
 
     def reset(self, team_obs, dummy=False):
-        super().reset(team_obs)
-        if not dummy:
-            if self._replay_helper is None and self._replay_save_dir is not None:
-                self._replay_helper = FileReplayHelper()
-                self.env.realm.record_replay(self._replay_helper)
-            if self._replay_helper is not None:
-                self._replay_helper.reset()
+        super().reset(team_obs, dummy)
 
-        self._reset_episode_stats()
+    def actions(self, team_actions, step):
+        """Called in _prestep() via _handle_actions().
+           See https://github.com/PufferAI/PufferLib/blob/0.3/pufferlib/emulation.py#L192
+        """
+        # Default action handler does nothing. Add custom action handling here.
+        return team_actions
 
-    def _reset_episode_stats(self):
-        self._cod_attacked = 0
-        self._cod_starved = 0
-        self._cod_dehydrated = 0
-        self._task_completed = 0
-        self._curriculum = defaultdict(list)
+    def features(self, obs, step):
+        """Called in _poststep() via _featurize().
+           See https://github.com/PufferAI/PufferLib/blob/0.3/pufferlib/emulation.py#L309
+        """
+        # Default featurizer pads observations to max team size
+        team_features = super().features(obs, step)  # DO NOT REMOVE
 
-        # for team results
-        # CHECK ME: perhaps create a stat wrapper for putting all stats in one place?
-        self._time_alive = 0
-        self._gold_owned = 0
-        self._damage_received = 0
-        self._damage_inflicted = 0
-        self._ration_consumed = 0
-        self._potion_consumed = 0
-        self._melee_level = 0
-        self._range_level = 0
-        self._mage_level = 0
-        self._fishing_level = 0
-        self._herbalism_level = 0
-        self._prospecting_level = 0
-        self._carving_level = 0
-        self._alchemy_level = 0
-
-    def _update_stats(self, agent):
-        task = self.env.agent_task_map[agent.ent_id][0]
-        # For each task spec, record whether its max progress and reward count
-        self._curriculum[task.spec_name].append((task._max_progress, task.reward_signal_count))
-        if task.completed:
-            self._task_completed += 1.0 / self.team_size
-
-        if agent.damage.val > 0:
-            self._cod_attacked += 1.0 / self.team_size
-        elif agent.food.val == 0:
-            self._cod_starved += 1.0 / self.team_size
-        elif agent.water.val == 0:
-            self._cod_dehydrated += 1.0 / self.team_size
-
-        # For TeamResult
-        self._time_alive += agent.history.time_alive.val
-        self._gold_owned += agent.gold.val
-        self._damage_received += agent.history.damage_received
-        self._damage_inflicted += agent.history.damage_inflicted
-        self._ration_consumed += agent.ration_consumed
-        self._potion_consumed += agent.poultice_consumed
-        self._melee_level += agent.melee_level.val
-        self._range_level += agent.range_level.val
-        self._mage_level += agent.mage_level.val
-        self._fishing_level += agent.fishing_level.val
-        self._herbalism_level += agent.herbalism_level.val
-        self._prospecting_level += agent.prospecting_level.val
-        self._carving_level += agent.carving_level.val
-        self._alchemy_level += agent.alchemy_level.val
+        # Add custom featurization here.
+        return team_features
 
     def rewards(self, team_rewards, team_dones, team_infos, step):
-        """Calculate team rewards and update stats."""
+        """Called in _poststep() via _shape_rewards().
+           See https://github.com/PufferAI/PufferLib/blob/0.3/pufferlib/emulation.py#L322
+        """
+        # The below line updates the stats and does not affect the reward.
+        super().rewards(team_rewards, team_dones, team_infos, step)  # DO NOT REMOVE
 
-        team_reward = sum(team_rewards.values())
-        team_info = {"stats": defaultdict(float)}
-
-        for agent_id in team_dones:
-            if team_dones[agent_id] is True:
-                agent = self.env.realm.players.dead_this_tick.get(
-                    agent_id, self.env.realm.players.get(agent_id)
-                )
-                if agent is None:
-                    continue
-                self._update_stats(agent)
-
-        return team_reward, team_info
+        # Default reward shaper sums team rewards.
+        # Add custom reward shaping here.
+        return sum(team_rewards.values()), team_infos
 
     def infos(self, team_reward, env_done, team_done, team_infos, step):
-        """Update team infos and save replays."""
+        """Called in _poststep() via _handle_infos().
+           See https://github.com/PufferAI/PufferLib/blob/0.3/pufferlib/emulation.py#L348
+        """
+        # The below line processes the necessary stats.
+        team_infos = super().infos(team_reward, env_done, team_done, team_infos, step)  # DO NOT REMOVE
 
-        team_infos = super().infos(team_reward, env_done, team_done, team_infos, step)
-
-        if env_done:
-            team_infos["stats"]["cod/attacked"] = self._cod_attacked
-            team_infos["stats"]["cod/starved"] = self._cod_starved
-            team_infos["stats"]["cod/dehydrated"] = self._cod_dehydrated
-            team_infos["stats"]["task/completed"] = self._task_completed
-            team_infos["curriculum"] = self._curriculum
-
-            team_result, achieved, performed, _ = get_team_result(
-                self.env.realm, self.teams, self.team_id
-            )
-            for key, val in list(achieved.items()) + list(performed.items()):
-                team_infos["stats"][key] = float(val)
-
-            # Fill in the TeamResult
-            team_result.time_alive = self._time_alive
-            team_result.gold_owned = self._gold_owned
-            team_result.completed_task_count = round(self._task_completed * self.team_size)
-            team_result.damage_received = self._damage_received
-            team_result.damage_inflicted = self._damage_inflicted
-            team_result.ration_consumed = self._ration_consumed
-            team_result.potion_consumed = self._potion_consumed
-            team_result.melee_level = self._melee_level
-            team_result.range_level = self._range_level
-            team_result.mage_level = self._mage_level
-            team_result.fishing_level = self._fishing_level
-            team_result.herbalism_level = self._herbalism_level
-            team_result.prospecting_level = self._prospecting_level
-            team_result.carving_level = self._carving_level
-            team_result.alchemy_level = self._alchemy_level
-
-            team_infos["team_results"] = (self.team_id, team_result)
-
-            if self._replay_save_dir is not None:
-                self._replay_helper.save(
-                    os.path.join(
-                        self._replay_save_dir, f"replay_{time.strftime('%Y%m%d_%H%M%S')}"), compress=False)
-                self._num_replays_saved += 1
-
+        # Add custom infos here.
         return team_infos
 
 

--- a/leader_board.py
+++ b/leader_board.py
@@ -1,10 +1,18 @@
+import os
+import time
+import logging
 from typing import Optional, List
 from dataclasses import dataclass
+from collections import defaultdict
 
 import numpy as np
 
+import pufferlib
+import pufferlib.emulation
+
 from nmmo.core.realm import Realm
 from nmmo.lib.log import EventCode
+from nmmo.render.replay_helper import FileReplayHelper
 
 
 @dataclass
@@ -98,6 +106,139 @@ def get_team_result(realm: Realm, teams, team_id):
 
     return team_result, achieved, performed, event_cnt
 
+
+class StatPostprocessor(pufferlib.emulation.Postprocessor):
+    """Postprocessing actions and metrics of Neural MMO.
+       Process wandb/leader board stats, and save replays.
+    """
+    def __init__(self, env, teams, team_id, replay_save_dir=None):
+        super().__init__(env, teams, team_id)
+        self._num_replays_saved = 0
+        self._replay_save_dir = None
+        if replay_save_dir is not None and self.team_id == 1:
+            self._replay_save_dir = replay_save_dir
+        self._replay_helper = None
+        self._reset_episode_stats()
+
+    def reset(self, team_obs, dummy=False):
+        super().reset(team_obs)
+        if not dummy:
+            if self._replay_helper is None and self._replay_save_dir is not None:
+                self._replay_helper = FileReplayHelper()
+                self.env.realm.record_replay(self._replay_helper)
+            if self._replay_helper is not None:
+                self._replay_helper.reset()
+
+        self._reset_episode_stats()
+
+    def _reset_episode_stats(self):
+        self._cod_attacked = 0
+        self._cod_starved = 0
+        self._cod_dehydrated = 0
+        self._task_completed = 0
+        self._curriculum = defaultdict(list)
+
+        # for team results
+        self._time_alive = 0
+        self._gold_owned = 0
+        self._damage_received = 0
+        self._damage_inflicted = 0
+        self._ration_consumed = 0
+        self._potion_consumed = 0
+        self._melee_level = 0
+        self._range_level = 0
+        self._mage_level = 0
+        self._fishing_level = 0
+        self._herbalism_level = 0
+        self._prospecting_level = 0
+        self._carving_level = 0
+        self._alchemy_level = 0
+
+    def _update_stats(self, agent):
+        task = self.env.agent_task_map[agent.ent_id][0]
+        # For each task spec, record whether its max progress and reward count
+        self._curriculum[task.spec_name].append((task._max_progress, task.reward_signal_count))
+        if task.completed:
+            self._task_completed += 1.0 / self.team_size
+
+        if agent.damage.val > 0:
+            self._cod_attacked += 1.0 / self.team_size
+        elif agent.food.val == 0:
+            self._cod_starved += 1.0 / self.team_size
+        elif agent.water.val == 0:
+            self._cod_dehydrated += 1.0 / self.team_size
+
+        # For TeamResult
+        self._time_alive += agent.history.time_alive.val
+        self._gold_owned += agent.gold.val
+        self._damage_received += agent.history.damage_received
+        self._damage_inflicted += agent.history.damage_inflicted
+        self._ration_consumed += agent.ration_consumed
+        self._potion_consumed += agent.poultice_consumed
+        self._melee_level += agent.melee_level.val
+        self._range_level += agent.range_level.val
+        self._mage_level += agent.mage_level.val
+        self._fishing_level += agent.fishing_level.val
+        self._herbalism_level += agent.herbalism_level.val
+        self._prospecting_level += agent.prospecting_level.val
+        self._carving_level += agent.carving_level.val
+        self._alchemy_level += agent.alchemy_level.val
+
+    def rewards(self, team_rewards, team_dones, team_infos, step):
+        for agent_id in team_dones:
+            if team_dones[agent_id] is True:
+                agent = self.env.realm.players.dead_this_tick.get(
+                    agent_id, self.env.realm.players.get(agent_id)
+                )
+                if agent is None:
+                    continue
+                self._update_stats(agent)
+
+    def infos(self, team_reward, env_done, team_done, team_infos, step):
+        """Update team infos and save replays."""
+        team_infos = super().infos(team_reward, env_done, team_done, team_infos, step)
+        team_infos["stats"] = defaultdict(float)
+
+        if env_done:
+            team_infos["stats"]["cod/attacked"] = self._cod_attacked
+            team_infos["stats"]["cod/starved"] = self._cod_starved
+            team_infos["stats"]["cod/dehydrated"] = self._cod_dehydrated
+            team_infos["stats"]["task/completed"] = self._task_completed
+            team_infos["curriculum"] = self._curriculum
+
+            team_result, achieved, performed, _ = get_team_result(
+                self.env.realm, self.teams, self.team_id
+            )
+            for key, val in list(achieved.items()) + list(performed.items()):
+                team_infos["stats"][key] = float(val)
+
+            # Fill in the TeamResult
+            team_result.time_alive = self._time_alive
+            team_result.gold_owned = self._gold_owned
+            team_result.completed_task_count = round(self._task_completed * self.team_size)
+            team_result.damage_received = self._damage_received
+            team_result.damage_inflicted = self._damage_inflicted
+            team_result.ration_consumed = self._ration_consumed
+            team_result.potion_consumed = self._potion_consumed
+            team_result.melee_level = self._melee_level
+            team_result.range_level = self._range_level
+            team_result.mage_level = self._mage_level
+            team_result.fishing_level = self._fishing_level
+            team_result.herbalism_level = self._herbalism_level
+            team_result.prospecting_level = self._prospecting_level
+            team_result.carving_level = self._carving_level
+            team_result.alchemy_level = self._alchemy_level
+
+            team_infos["team_results"] = (self.team_id, team_result)
+
+            if self._replay_helper is not None:
+                replay_file = os.path.join(
+                    self._replay_save_dir, f"replay_{time.strftime('%Y%m%d_%H%M%S')}")
+                logging.info("Saving replay to %s", replay_file)
+                self._replay_helper.save(replay_file, compress=False)
+                self._num_replays_saved += 1
+
+        return team_infos
 
 # Event processing utilities for Neural MMO.
 

--- a/leader_board.py
+++ b/leader_board.py
@@ -197,7 +197,6 @@ class StatPostprocessor(pufferlib.emulation.Postprocessor):
     def infos(self, team_reward, env_done, team_done, team_infos, step):
         """Update team infos and save replays."""
         team_infos = super().infos(team_reward, env_done, team_done, team_infos, step)
-        team_infos["stats"] = defaultdict(float)
 
         if env_done:
             team_infos["stats"]["cod/attacked"] = self._cod_attacked


### PR DESCRIPTION
* simplified `environment.py` Postprocessor, by moving the wandb/leader board stats, replay to `leader_board.py`
* added comments to the Postprocessor methods: actions, features, rewards, infos