### PR TITLE
curriculum track bug fix

### DIFF
--- a/train.py
+++ b/train.py
@@ -114,6 +114,7 @@ def curriculum_generation_track(trainer, args, use_elm=True):
     # Use the train_task_spec to train agents
     task_encoder.get_task_embedding(curriculum, save_to_file=CUSTOM_CURRICULUM_FILE)
     task_encoder.close()
+    trainer.data.sort_keys = []
     reinforcement_learning_track(trainer, args)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix the below error from the nmmo discord. The `sort_keys` was accumulating during `evaluate()`, which is only cleared within `train()`.

```
Epoch: 0 - 131K steps - 0:03:34 Elapsed
        Steps Per Second: Env=825, Inference=11072
Traceback (most recent call last):
  File "/puffertank/nmmo-baselines/train.py", line 140, in <module>
    curriculum_generation_track(trainer, args, use_elm=True)
  File "/puffertank/nmmo-baselines/train.py", line 117, in curriculum_generation_track
    reinforcement_learning_track(trainer, args)
  File "/puffertank/nmmo-baselines/train.py", line 70, in reinforcement_learning_track
    trainer.train(
  File "/puffertank/pufferlib/pufferlib/utils.py", line 222, in wrapper
    result = func(*args, **kwargs)
  File "/puffertank/pufferlib/clean_pufferl.py", line 497, in train
    .reshape(batch_rows, num_minibatches, bptt_horizon)
RuntimeError: shape '[16, 256, 8]' is invalid for input of size 131075
```